### PR TITLE
updated and rework of JPS

### DIFF
--- a/manifest.jps
+++ b/manifest.jps
@@ -1,45 +1,60 @@
-{
-	"jpsVersion": "0.2",
-	"jpsType": "install",
-	"application": {
-		"id": "nexus",
-		"name": "Nexus Repository Manager",
-		"version": "2.12.0-01",
-		"logo": "https://raw.githubusercontent.com/jelastic-jps/nexus/master/images/Nexus.png",
-		"type": "java",
-		"homepage": "http://www.sonatype.org/",
-		"categories": ["apps/dev-tools", "apps/dev-and-admin-tools"],
-		"description": {
-			"en": "Nexus sets the standard for repository management providing development teams with the ability to proxy remote repositories and share software artifacts."
-		},
-		"env": {
-			"topology": {
-				"ha": false,
-				"engine": "java7",
-				"ssl": false,
-				"nodes": [{
-						"extip": false,
-						"count": 1,
-						"cloudlets": 8,
-						"nodeType": "tomcat7"
-					}
-				]
-			},
-			"deployments": [{
-					"archive": "https://raw.githubusercontent.com/jelastic-jps/nexus/master/dumps/nexus-2.12.0-01.war",
-					"name": "nexus-2.12.0-01.war",
-					"context": "ROOT"
-				}
-			],
-			"configs": [{
-					"nodeType": "tomcat7",
-					"restart": true
-				}
-			]
-		},
-		"success": {
-			"text": "Below you will find your admin panel link, username and password.</br></br> <table style='font-size:13px; border: none;'><tr><td>Admin panel URL:</td><td style='padding-left: 10px;'><a href='${env.protocol}://${env.domain}/' target='_blank'>${env.protocol}://${env.domain}/</a></td></tr>  <tr><td>Admin name:</td><td style='padding-left: 10px;'>admin</td></tr><tr><td>Password:</td><td style='padding-left: 10px;'>admin123</td></tr></table></br>To add custom domain name for your Nexus Repository Manager installation follow the steps described in our <a href='http://docs.jelastic.com/custom-domains' target='_blank'>documentation</a>",
-			"email": "Below you will find your admin panel link, username and password.</br></br> <table style='font-size:13px; border: none;'><tr><td>Admin panel URL:</td><td style='padding-left: 10px;'><a href='${env.protocol}://${env.domain}/' target='_blank'>${env.protocol}://${env.domain}/</a></td></tr>  <tr><td>Admin name:</td><td style='padding-left: 10px;'>admin</td></tr><tr><td>Password:</td><td style='padding-left: 10px;'>admin123</td></tr></table></br>To add custom domain name for your Nexus Repository Manager installation follow the steps described in our <a href='http://docs.jelastic.com/custom-domains' target='_blank'>documentation</a>"
-		}
-	}
-}
+jpsVersion: '0.2'
+jpsType: install
+application:
+  id: nexus
+  name: Nexus Repository Manager
+  version: 2.12.0-01
+  logo: 'https://raw.githubusercontent.com/jelastic-jps/nexus/master/images/Nexus.png'
+  type: java
+  homepage: 'http://www.sonatype.org/'
+  categories:
+    - apps/dev-tools
+    - apps/dev-and-admin-tools
+  description:
+    en: >-
+      Nexus sets the standard for repository management providing development
+      teams with the ability to proxy remote repositories and share software
+      artifacts.
+  env:
+    topology:
+      ha: false
+      engine: java7
+      ssl: false
+      nodes:
+        - extip: false
+          count: 1
+          cloudlets: 8
+          nodeType: tomcat7
+    deployments:
+      - archive: >-
+          https://raw.githubusercontent.com/jelastic-jps/nexus/master/dumps/nexus-2.12.0-01.war
+        name: nexus-2.12.0-01.war
+        context: ROOT
+    configs:
+      - nodeType: tomcat7
+        restart: true
+  success:
+    text: >-
+      Below you will find your admin panel link, username and
+      password.</br></br> <table style='font-size:13px; border:
+      none;'><tr><td>Admin panel URL:</td><td style='padding-left: 10px;'><a
+      href='${env.protocol}://${env.domain}/'
+      target='_blank'>${env.protocol}://${env.domain}/</a></td></tr> 
+      <tr><td>Admin name:</td><td style='padding-left:
+      10px;'>admin</td></tr><tr><td>Password:</td><td style='padding-left:
+      10px;'>admin123</td></tr></table></br>To add custom domain name for your
+      Nexus Repository Manager installation follow the steps described in our <a
+      href='http://docs.jelastic.com/custom-domains'
+      target='_blank'>documentation</a>
+    email: >-
+      Below you will find your admin panel link, username and
+      password.</br></br> <table style='font-size:13px; border:
+      none;'><tr><td>Admin panel URL:</td><td style='padding-left: 10px;'><a
+      href='${env.protocol}://${env.domain}/'
+      target='_blank'>${env.protocol}://${env.domain}/</a></td></tr> 
+      <tr><td>Admin name:</td><td style='padding-left:
+      10px;'>admin</td></tr><tr><td>Password:</td><td style='padding-left:
+      10px;'>admin123</td></tr></table></br>To add custom domain name for your
+      Nexus Repository Manager installation follow the steps described in our <a
+      href='http://docs.jelastic.com/custom-domains'
+      target='_blank'>documentation</a>

--- a/manifest.jps
+++ b/manifest.jps
@@ -1,6 +1,6 @@
 type: install 
 name: Nexus Repository Manager
-baseUrl: https://raw.githubusercontent.com/panslothda/nexus/master/
+baseUrl: https://raw.githubusercontent.com/jelastic-jps/nexus/master/
 logo: images/Nexus.png
 homepage: https://www.sonatype.com/products/repository-oss
 description: Nexus Repository OSS is an open source repository that supports many artifact formats, including Docker, Java and npm. 
@@ -68,7 +68,7 @@ addons:
     actions:
       update:
         - log: launching nexus update JPS
-        - install: https://raw.githubusercontent.com/panslothda/nexus/master/scripts/update-nexus.jps
+        - install: https://raw.githubusercontent.com/jelastic-jps/nexus/master/scripts/update-nexus.jps
           skipEmail: true
 
 success:

--- a/manifest.jps
+++ b/manifest.jps
@@ -10,7 +10,6 @@ categories:
   - apps/dev-tools
   - apps/dev-and-admin-tools
 
-
 env:
   ssl: true
   nodes:
@@ -19,28 +18,42 @@ env:
     nodeType: nginxphp
 
 onInstall:
-	- install-package
+	- install-nexus
 	- setup-nginx
   - installAddon:
       id: update-nexus
       nodeGroup: cp
 
 actions:
-  install-package:
+  install-nexus:
 		- cmd[cp]: |-
         wget -P /etc/yum.repos.d/ https://repo.sonatype.com/repository/community-hosted/rpm/sonatype-community.repo &>> /var/log/run.log
         yum -y update &>> /var/log/run.log
         yum -y install nexus-repository-manager &>> /var/log/run.log
         echo /opt/sonatype/ >> /etc/jelastic/redeploy.conf
+        sleep 10
+        chmod 664 /opt/sonatype/sonatype-work/nexus3/etc/nexus.properties
+        usermod -a -G nexus3 jelastic
       user: root
       sayYes: true
 
   setup-nginx:
 		- cmd[cp]: |-
         sed -i '74d' /etc/nginx/nginx.conf
-        sed -i "74i proxy_pass http://localhost:8081/;"  /etc/nginx/nginx.conf
+        sed -i "74i 	 proxy_pass http://localhost:8081/;"  /etc/nginx/nginx.conf
+        sed -i '75i    proxy_set_header Host $host;'  /etc/nginx/nginx.conf
+        sed -i '76i    proxy_set_header X-Real-IP $remote_addr;'  /etc/nginx/nginx.conf
+        sed -i '77i    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;'  /etc/nginx/nginx.conf
       user: root
       sayYes: true
+    - replaceInFile:
+      	nodeType: nginxphp
+      	path: /opt/sonatype/sonatype-work/nexus3/etc/nexus.properties
+      	replacements:
+        	- pattern: '# application-host=0.0.0.0'
+          	replacement: 'application-host=127.0.0.1'
+		- api [cp]: jelastic.environment.control.RestartNodes
+		- cmd [cp]: sleep 15
 
 addons:
   - id: update-nexus
@@ -54,8 +67,8 @@ addons:
         successText: Nexus and CentOS have been successfully updated!
     actions:
       update:
-        - log: launching grafana update JPS
-        - install: https://raw.githubusercontent.com/panslothda/nexus/main/scripts/update-nexus.jps
+        - log: launching nexus update JPS
+        - install: https://raw.githubusercontent.com/panslothda/nexus/master/scripts/update-nexus.jps
           skipEmail: true
 
 success:

--- a/manifest.jps
+++ b/manifest.jps
@@ -1,60 +1,63 @@
-jpsVersion: '0.2'
-jpsType: install
-application:
-  id: nexus
-  name: Nexus Repository Manager
-  version: 2.12.0-01
-  logo: 'https://raw.githubusercontent.com/jelastic-jps/nexus/master/images/Nexus.png'
-  type: java
-  homepage: 'http://www.sonatype.org/'
-  categories:
-    - apps/dev-tools
-    - apps/dev-and-admin-tools
-  description:
-    en: >-
-      Nexus sets the standard for repository management providing development
-      teams with the ability to proxy remote repositories and share software
-      artifacts.
-  env:
-    topology:
-      ha: false
-      engine: java7
-      ssl: false
-      nodes:
-        - extip: false
-          count: 1
-          cloudlets: 8
-          nodeType: tomcat7
-    deployments:
-      - archive: >-
-          https://raw.githubusercontent.com/jelastic-jps/nexus/master/dumps/nexus-2.12.0-01.war
-        name: nexus-2.12.0-01.war
-        context: ROOT
-    configs:
-      - nodeType: tomcat7
-        restart: true
-  success:
-    text: >-
-      Below you will find your admin panel link, username and
-      password.</br></br> <table style='font-size:13px; border:
-      none;'><tr><td>Admin panel URL:</td><td style='padding-left: 10px;'><a
-      href='${env.protocol}://${env.domain}/'
-      target='_blank'>${env.protocol}://${env.domain}/</a></td></tr> 
-      <tr><td>Admin name:</td><td style='padding-left:
-      10px;'>admin</td></tr><tr><td>Password:</td><td style='padding-left:
-      10px;'>admin123</td></tr></table></br>To add custom domain name for your
-      Nexus Repository Manager installation follow the steps described in our <a
-      href='http://docs.jelastic.com/custom-domains'
-      target='_blank'>documentation</a>
-    email: >-
-      Below you will find your admin panel link, username and
-      password.</br></br> <table style='font-size:13px; border:
-      none;'><tr><td>Admin panel URL:</td><td style='padding-left: 10px;'><a
-      href='${env.protocol}://${env.domain}/'
-      target='_blank'>${env.protocol}://${env.domain}/</a></td></tr> 
-      <tr><td>Admin name:</td><td style='padding-left:
-      10px;'>admin</td></tr><tr><td>Password:</td><td style='padding-left:
-      10px;'>admin123</td></tr></table></br>To add custom domain name for your
-      Nexus Repository Manager installation follow the steps described in our <a
-      href='http://docs.jelastic.com/custom-domains'
-      target='_blank'>documentation</a>
+type: install 
+name: Nexus Repository Manager
+baseUrl: https://raw.githubusercontent.com/panslothda/nexus/master/
+logo: images/Nexus.png
+homepage: https://www.sonatype.com/products/repository-oss
+description: Nexus Repository OSS is an open source repository that supports many artifact formats, including Docker, Java and npm. 
+  With the Nexus tool integration, pipelines in your toolchain can publish and retrieve versioned apps and their dependencies by using central repositories that are accessible from other environments.
+
+categories:
+  - apps/dev-tools
+  - apps/dev-and-admin-tools
+
+
+env:
+  ssl: true
+  nodes:
+  - cloudlets: 32
+    fixedCloudlets: 1
+    nodeType: nginxphp
+
+onInstall:
+	- install-package
+	- setup-nginx
+  - installAddon:
+      id: update-nexus
+      nodeGroup: cp
+
+actions:
+  install-package:
+		- cmd[cp]: |-
+        wget -P /etc/yum.repos.d/ https://repo.sonatype.com/repository/community-hosted/rpm/sonatype-community.repo &>> /var/log/run.log
+        yum -y update &>> /var/log/run.log
+        yum -y install nexus-repository-manager &>> /var/log/run.log
+        echo /opt/sonatype/ >> /etc/jelastic/redeploy.conf
+      user: root
+      sayYes: true
+
+  setup-nginx:
+		- cmd[cp]: |-
+        sed -i '74d' /etc/nginx/nginx.conf
+        sed -i "74i proxy_pass http://localhost:8081/;"  /etc/nginx/nginx.conf
+      user: root
+      sayYes: true
+
+addons:
+  - id: update-nexus
+    name: Update Nexus Repository Manager
+    description: Update of Nexus and CentOS
+    buttons:
+      - caption: Update
+        action: update
+        loadingText: Updating...
+        confirmText: Do you want to update Nexus and CentOS?
+        successText: Nexus and CentOS have been successfully updated!
+    actions:
+      update:
+        - log: launching grafana update JPS
+        - install: https://raw.githubusercontent.com/panslothda/nexus/main/scripts/update-nexus.jps
+          skipEmail: true
+
+success:
+  email: text/success-email.md
+  text: text/success-text.md

--- a/scripts/update-nexus.jps
+++ b/scripts/update-nexus.jps
@@ -1,0 +1,25 @@
+type: update
+name: Nexus Server Upgrade 
+logo: https://raw.githubusercontent.com/jelastic-jps/nexus/master/images/Nexus.png
+
+description: |
+  This Addon allows you to upgrade Nexus and CentOS.  
+
+targetNodes:
+  nodeGroup: [cp]
+ 
+onInstall:
+  - update-packages
+  - restart
+
+actions:
+  update-packages:
+    - log: update of Centos
+    - cmd [cp]: yum -y update &>> /var/log/run.log
+      user: root
+      sayYes: true
+  restart:
+    - api [cp]: jelastic.environment.control.RestartNodes 
+
+success:
+  text: Nexus and CentOS have been updated

--- a/text/success-email.md
+++ b/text/success-email.md
@@ -1,8 +1,8 @@
  Below you will find your admin panel link, username and password. 
 
- Admin panel URL: [${env.protocol}://${env.domain}/](${env.protocol}://${env.domain}/)  
- Admin name: admin  
- Password: admin123  
+ **Admin panel URL**: [https://${env.domain}/](https://${env.domain}/)  
+ **Admin name**: admin  
+ **Password**: Initial password is found in the file /opt/sonatype/sonatype-work/nexus3/admin.password
 
  To add custom domain name for your ownCloud installation follow the steps described in our [documentation](http://docs.jelastic.com/custom-domains)
  

--- a/text/success-email.md
+++ b/text/success-email.md
@@ -1,0 +1,9 @@
+ Below you will find your admin panel link, username and password. 
+
+ Admin panel URL: [${env.protocol}://${env.domain}/](${env.protocol}://${env.domain}/)  
+ Admin name: admin  
+ Password: admin123  
+
+ To add custom domain name for your ownCloud installation follow the steps described in our [documentation](http://docs.jelastic.com/custom-domains)
+ 
+ You can find an overview of nexus in the official docs, here is a good starting point: https://help.sonatype.com/repomanager3/user-interface/user-interface-overview

--- a/text/success-text.md
+++ b/text/success-text.md
@@ -1,5 +1,5 @@
- Below you will find your admin panel link, username and password. 
+Nexus has been installed and is ready for setup!
 
- Admin panel URL: [${env.protocol}://${env.domain}/](${env.protocol}://${env.domain}/)  
- Admin name: admin  
- Password: admin123  
+ **Admin panel URL**: [https://${env.domain}/](https://${env.domain}/)  
+ **Admin name**: admin  
+ **Password**: Initial password is found in the file /opt/sonatype/sonatype-work/nexus3/admin.password

--- a/text/success-text.md
+++ b/text/success-text.md
@@ -1,0 +1,5 @@
+ Below you will find your admin panel link, username and password. 
+
+ Admin panel URL: [${env.protocol}://${env.domain}/](${env.protocol}://${env.domain}/)  
+ Admin name: admin  
+ Password: admin123  


### PR DESCRIPTION
Hi,

Here is an update of the JPS and its components:

Changes:

converted jps to yaml
activated built-in SSL by default
changed from java to nginx as app server (nginx is just reverse proxy)
updated to nexus repository manager 3
included an update addon and script
Split out text for success message into dedicated files
Separate messages for e-mail and direct text with individual infos
set appropriate cloudlets for idle load

I tested it on the infomaniak platform but not on other ones and for me it worked well :)

Let me know if you have any comments or questions